### PR TITLE
Call super for proper logging init

### DIFF
--- a/addons/escoria-core/game/esc_logger.gd
+++ b/addons/escoria-core/game/esc_logger.gd
@@ -93,6 +93,7 @@ class ESCLoggerFile extends ESCLoggerBase:
 
 	# Constructor
 	func _init():
+		super()
 		# This is left alone as this constructor is called from escoria.gd's own
 		# constructor
 		var log_file_path = ProjectSettings.get_setting(


### PR DESCRIPTION
Fixed esc logging to console by calling "super()"