### PR TITLE
Fix internationalization

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_animation_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_animation_player.gd
@@ -166,9 +166,7 @@ func is_valid() -> bool:
 #
 # - name: Name of the animation played
 func _on_animation_finished(name: String):
-	if _is_animation_player and not _animation_player.get_animation(name).loop_mode > Animation.LOOP_NONE:
-		_animation_player.stop()
-	elif not _animated_sprite.frames.get_animation_loop(name):
+	if not _is_animation_player and not _animated_sprite.frames.get_animation_loop(name):
 		_animated_sprite.stop()
 	animation_finished.emit(name)
 

--- a/project.godot
+++ b/project.godot
@@ -108,6 +108,10 @@ switch_action_verb={
 ]
 }
 
+[internationalization]
+
+locale/translations=PackedStringArray("res://game/translations/game.de.translation", "res://game/translations/game.en.translation", "res://game/translations/game.es.translation", "res://game/translations/game.fr.translation", "res://game/translations/main_menu.de.translation", "res://game/translations/main_menu.en.translation", "res://game/translations/main_menu.es.translation", "res://game/translations/main_menu.fr.translation")
+
 [locale]
 
 translations=PackedStringArray("res://game/translations/game.en.translation", "res://game/translations/game.fr.translation", "res://game/translations/main_menu.en.translation", "res://game/translations/main_menu.fr.translation", "res://game/translations/game.de.translation", "res://game/translations/main_menu.de.translation", "res://game/translations/game.es.translation", "res://game/translations/main_menu.es.translation")


### PR DESCRIPTION
Internationalization files listed in project.godot are now under a different section called "[internationalization]".

With this fix, main menu is translated correctly and language flags are shown in options menu.